### PR TITLE
Fix usage of AllocVal in ForwardQueries when propagating their facts

### DIFF
--- a/boomerangPDS/src/main/java/boomerang/ForwardQuery.java
+++ b/boomerangPDS/src/main/java/boomerang/ForwardQuery.java
@@ -16,19 +16,38 @@ package boomerang;
 
 import boomerang.scope.AllocVal;
 import boomerang.scope.ControlFlowGraph;
+import java.util.Objects;
 
 public class ForwardQuery extends Query {
 
-  public ForwardQuery(ControlFlowGraph.Edge edge, AllocVal variable) {
-    super(edge, variable);
+  private final AllocVal allocVal;
+
+  public ForwardQuery(ControlFlowGraph.Edge edge, AllocVal allocVal) {
+    super(edge, allocVal.getDelegate());
+
+    this.allocVal = allocVal;
   }
 
   public AllocVal getAllocVal() {
-    return (AllocVal) var();
+    return allocVal;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    ForwardQuery that = (ForwardQuery) o;
+    return Objects.equals(allocVal, that.allocVal);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), allocVal);
   }
 
   @Override
   public String toString() {
-    return "ForwardQuery: " + super.toString();
+    return "ForwardQuery: " + allocVal;
   }
 }

--- a/boomerangPDS/src/main/java/boomerang/WeightedForwardQuery.java
+++ b/boomerangPDS/src/main/java/boomerang/WeightedForwardQuery.java
@@ -16,6 +16,7 @@ package boomerang;
 
 import boomerang.scope.AllocVal;
 import boomerang.scope.ControlFlowGraph.Edge;
+import java.util.Objects;
 import wpds.impl.Weight;
 
 public class WeightedForwardQuery<W extends Weight> extends ForwardQuery {
@@ -29,5 +30,24 @@ public class WeightedForwardQuery<W extends Weight> extends ForwardQuery {
 
   public W weight() {
     return weight;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    WeightedForwardQuery<?> that = (WeightedForwardQuery<?>) o;
+    return Objects.equals(weight, that.weight);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), weight);
+  }
+
+  @Override
+  public String toString() {
+    return "Weighted Forward Query: " + getAllocVal() + ", " + weight;
   }
 }

--- a/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
+++ b/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
@@ -20,7 +20,6 @@ import boomerang.callgraph.CallerListener;
 import boomerang.callgraph.ObservableICFG;
 import boomerang.controlflowgraph.ObservableControlFlowGraph;
 import boomerang.options.BoomerangOptions;
-import boomerang.scope.AllocVal;
 import boomerang.scope.ControlFlowGraph;
 import boomerang.scope.ControlFlowGraph.Edge;
 import boomerang.scope.DataFlowScope;
@@ -193,13 +192,10 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
           public void callWitness(Transition<ControlFlowGraph.Edge, INode<Val>> t) {
 
             Val targetFact = t.getTarget().fact();
-            if (targetFact instanceof AllocVal) {
-              targetFact = ((AllocVal) targetFact).getDelegate();
-              if (!potentialCallCandidate.add(targetFact)) return;
-              if (potentialFieldCandidate.containsKey(targetFact)) {
-                for (Node<ControlFlowGraph.Edge, Val> w : potentialFieldCandidate.get(targetFact)) {
-                  listener.witnessFound(w);
-                }
+            if (!potentialCallCandidate.add(targetFact)) return;
+            if (potentialFieldCandidate.containsKey(targetFact)) {
+              for (Node<ControlFlowGraph.Edge, Val> w : potentialFieldCandidate.get(targetFact)) {
+                listener.witnessFound(w);
               }
             }
           }

--- a/boomerangPDS/src/test/java/boomerang/guided/DemandDrivenGuidedAnalysisTest.java
+++ b/boomerangPDS/src/test/java/boomerang/guided/DemandDrivenGuidedAnalysisTest.java
@@ -16,7 +16,6 @@ package boomerang.guided;
 
 import boomerang.BackwardQuery;
 import boomerang.ForwardQuery;
-import boomerang.Query;
 import boomerang.QueryGraph;
 import boomerang.guided.targets.ArrayContainerTarget;
 import boomerang.guided.targets.BasicTarget;
@@ -568,15 +567,16 @@ public class DemandDrivenGuidedAnalysisTest {
 
     // Filter out query graph's node to only return the queries of interest (ForwardQueries &
     // String/Int Allocation sites).
-    Stream<Query> res =
+    Stream<ForwardQuery> res =
         queryGraph.getNodes().stream()
             .filter(
                 x ->
                     x instanceof ForwardQuery
-                        && isStringOrIntAllocation(x.asNode().stmt().getStart()));
+                        && isStringOrIntAllocation(x.asNode().stmt().getStart()))
+            .map(ForwardQuery.class::cast);
 
     Set<? extends Serializable> collect =
-        res.map(t -> ((AllocVal) t.var()).getAllocVal())
+        res.map(t -> t.getAllocVal().getAllocVal())
             .filter(x -> x.isStringConstant() || x.isIntConstant())
             .map(x -> (x.isIntConstant() ? x.getIntValue() : x.getStringValue()))
             .collect(Collectors.toSet());

--- a/boomerangPDS/src/test/java/test/core/AbstractBoomerangTest.java
+++ b/boomerangPDS/src/test/java/test/core/AbstractBoomerangTest.java
@@ -330,10 +330,12 @@ public class AbstractBoomerangTest extends TestingFramework {
       AnalysisMode analysis) {
     LOGGER.info(
         "Boomerang Results:\n - {}",
-        results.stream().map(r -> r.fact().toString()).collect(Collectors.joining("\n - ")));
+        results.stream().map(Node::toString).collect(Collectors.joining("\n - ")));
     LOGGER.info(
         "Expected Results:\n - {}",
-        expectedResults.stream().map(r -> r.var().toString()).collect(Collectors.joining("\n - ")));
+        expectedResults.stream()
+            .map(q -> q.asNode().toString())
+            .collect(Collectors.joining("\n - ")));
     Collection<Node<Edge, Val>> falseNegativeAllocationSites = new HashSet<>();
     for (Query res : expectedResults) {
       if (!results.contains(res.asNode())) falseNegativeAllocationSites.add(res.asNode());

--- a/idealPDS/src/main/java/ideal/IDEALSeedSolver.java
+++ b/idealPDS/src/main/java/ideal/IDEALSeedSolver.java
@@ -250,7 +250,7 @@ public class IDEALSeedSolver<W extends Weight> {
                 strongUpdateNode,
                 targetFact -> {
                   if (!e.getKey().asNode().equals(seed.asNode())) {
-                    if (!e.getKey().asNode().fact().isNull()) {
+                    if (!e.getKey().getAllocVal().getAllocVal().isNull()) {
                       setWeakUpdate(strongUpdateNode);
                     }
                   }

--- a/idealPDS/src/test/java/typestate/targets/FileMustBeClosedStrongUpdate.java
+++ b/idealPDS/src/test/java/typestate/targets/FileMustBeClosedStrongUpdate.java
@@ -40,6 +40,7 @@ public class FileMustBeClosedStrongUpdate {
     }
     b.close();
     Assertions.mayBeInErrorState(a);
+    Assertions.mayBeInErrorState(e);
     Assertions.mustBeInAcceptingState(b);
   }
 

--- a/idealPDS/src/test/java/typestate/tests/FileMustBeClosedStrongUpdateTest.java
+++ b/idealPDS/src/test/java/typestate/tests/FileMustBeClosedStrongUpdateTest.java
@@ -31,7 +31,7 @@ public class FileMustBeClosedStrongUpdateTest extends IDEALTestingFramework {
 
   @Test
   public void noStrongUpdatePossible() {
-    analyze(target, testName.getMethodName(), 2, 2);
+    analyze(target, testName.getMethodName(), 3, 2);
   }
 
   @Test


### PR DESCRIPTION
The forward and backward solver expect the propagated fact (i.e. the `var()` of a query) to be not an instance of the class `AllocVal`. However, in very specific situations, Boomerang creates generating states for the `AllocVal` because it is returned from `var()` in forward queries.

### Solution
Pass the delegate val from the `AllocVal` to the query object and treat the `AllocVal` as new field