### PR TITLE
Small fixes regarding types in OpalVal and TransitionFunctionImpl

### DIFF
--- a/boomerangPDS/src/main/java/boomerang/ForwardQuery.java
+++ b/boomerangPDS/src/main/java/boomerang/ForwardQuery.java
@@ -23,7 +23,7 @@ public class ForwardQuery extends Query {
   private final AllocVal allocVal;
 
   public ForwardQuery(ControlFlowGraph.Edge edge, AllocVal allocVal) {
-    super(edge, allocVal.getDelegate());
+    super(edge, allocVal);
 
     this.allocVal = allocVal;
   }

--- a/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
+++ b/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
@@ -20,6 +20,7 @@ import boomerang.callgraph.CallerListener;
 import boomerang.callgraph.ObservableICFG;
 import boomerang.controlflowgraph.ObservableControlFlowGraph;
 import boomerang.options.BoomerangOptions;
+import boomerang.scope.AllocVal;
 import boomerang.scope.ControlFlowGraph;
 import boomerang.scope.ControlFlowGraph.Edge;
 import boomerang.scope.DataFlowScope;
@@ -190,12 +191,16 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
 
           @Override
           public void callWitness(Transition<ControlFlowGraph.Edge, INode<Val>> t) {
-
             Val targetFact = t.getTarget().fact();
-            if (!potentialCallCandidate.add(targetFact)) return;
-            if (potentialFieldCandidate.containsKey(targetFact)) {
-              for (Node<ControlFlowGraph.Edge, Val> w : potentialFieldCandidate.get(targetFact)) {
-                listener.witnessFound(w);
+
+            if (targetFact instanceof AllocVal) {
+              targetFact = ((AllocVal) targetFact).getDelegate();
+
+              if (!potentialCallCandidate.add(targetFact)) return;
+              if (potentialFieldCandidate.containsKey(targetFact)) {
+                for (Node<ControlFlowGraph.Edge, Val> w : potentialFieldCandidate.get(targetFact)) {
+                  listener.witnessFound(w);
+                }
               }
             }
           }

--- a/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalType.scala
+++ b/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalType.scala
@@ -17,9 +17,41 @@ package boomerang.scope.opal.tac
 import boomerang.scope.Type
 import boomerang.scope.Val
 import boomerang.scope.WrappedClass
+import boomerang.scope.opal.transformation.TacLocal
 import java.util.Objects
+import org.opalj.br.ArrayType
+import org.opalj.br.DoubleType
+import org.opalj.br.FloatType
+import org.opalj.br.IntegerType
+import org.opalj.br.LongType
 import org.opalj.br.ObjectType
 import org.opalj.br.analyses.Project
+import org.opalj.tac.ArrayLength
+import org.opalj.tac.ArrayLoad
+import org.opalj.tac.BinaryExpr
+import org.opalj.tac.ClassConst
+import org.opalj.tac.Compare
+import org.opalj.tac.DoubleConst
+import org.opalj.tac.DynamicConst
+import org.opalj.tac.Expr
+import org.opalj.tac.FloatConst
+import org.opalj.tac.GetField
+import org.opalj.tac.GetStatic
+import org.opalj.tac.InstanceOf
+import org.opalj.tac.IntConst
+import org.opalj.tac.InvokedynamicFunctionCall
+import org.opalj.tac.LongConst
+import org.opalj.tac.MethodHandleConst
+import org.opalj.tac.MethodTypeConst
+import org.opalj.tac.New
+import org.opalj.tac.NewArray
+import org.opalj.tac.NonVirtualFunctionCall
+import org.opalj.tac.NullExpr
+import org.opalj.tac.PrefixExpr
+import org.opalj.tac.PrimitiveTypecastExpr
+import org.opalj.tac.StaticFunctionCall
+import org.opalj.tac.StringConst
+import org.opalj.tac.VirtualFunctionCall
 import org.opalj.value.ValueInformation
 
 class OpalType(val delegate: org.opalj.br.Type, project: Project[_]) extends Type {
@@ -45,17 +77,7 @@ class OpalType(val delegate: org.opalj.br.Type, project: Project[_]) extends Typ
       return false
     }
 
-    val sourceType = delegate.asReferenceType
-    val targetType =
-      targetValType.asInstanceOf[OpalType].delegate.asReferenceType
-
     false
-
-    /*target match {
-      case allocVal: AllocVal if allocVal.getAllocVal.isNewExpr => OpalClient.getClassHierarchy.isSubtypeOf(sourceType, targetType)
-
-      case _ => OpalClient.getClassHierarchy.isSubtypeOf(sourceType, targetType) || OpalClient.getClassHierarchy.isSubtypeOf(targetType, sourceType)
-    }*/
   }
 
   override def isSubtypeOf(otherType: String): Boolean = {
@@ -93,6 +115,44 @@ class OpalType(val delegate: org.opalj.br.Type, project: Project[_]) extends Typ
 }
 
 object OpalType {
+
+  def getTypeForExpr(expr: Expr[_], project: Project[_]): Type = {
+    expr match {
+      case instanceOf: InstanceOf[_] => return new OpalType(instanceOf.cmpTpe, project)
+      case _: Compare[_] => return new OpalType(IntegerType, project)
+      case methodTypeConst: MethodTypeConst => return new OpalType(methodTypeConst.value.returnType, project)
+      case methodHandleConst: MethodHandleConst =>
+        return new OpalType(methodHandleConst.value.runtimeValueType, project)
+      case _: IntConst => return new OpalType(IntegerType, project)
+      case _: LongConst => return new OpalType(LongType, project)
+      case _: FloatConst => return new OpalType(FloatType, project)
+      case _: DoubleConst => return new OpalType(DoubleType, project)
+      case _: StringConst => return new OpalType(ObjectType.String, project)
+      case classConst: ClassConst => return new OpalType(classConst.value, project)
+      case dynamicConst: DynamicConst => return new OpalType(dynamicConst.descriptor, project)
+      case nullExpr: NullExpr => return new OpalType(nullExpr.tpe, project)
+      case _: BinaryExpr[_] => return new OpalType(IntegerType, project)
+      case _: PrefixExpr[_] => return new OpalType(IntegerType, project)
+      case typeCast: PrimitiveTypecastExpr[_] => return new OpalType(typeCast.targetTpe, project)
+      case newExpr: New => return new OpalType(newExpr.tpe, project)
+      case newArray: NewArray[_] => return new OpalType(newArray.tpe, project)
+      case arrayLoad: ArrayLoad[_] =>
+        val arrayType = getTypeForExpr(arrayLoad.arrayRef, project).asInstanceOf[OpalType]
+        return new OpalType(ArrayType(arrayType.delegate.asFieldType), project)
+      case _: ArrayLength[_] => return new OpalType(IntegerType, project)
+      case getField: GetField[_] => return new OpalType(getField.declaredFieldType, project)
+      case getStatic: GetStatic => return new OpalType(getStatic.declaredFieldType, project)
+      case invokeDynamic: InvokedynamicFunctionCall[_] =>
+        return new OpalType(invokeDynamic.descriptor.returnType, project)
+      case functionCall: NonVirtualFunctionCall[_] => return new OpalType(functionCall.descriptor.returnType, project)
+      case functionCall: VirtualFunctionCall[_] => return new OpalType(functionCall.descriptor.returnType, project)
+      case functionCall: StaticFunctionCall[_] => return new OpalType(functionCall.descriptor.returnType, project)
+      case v: TacLocal => return valueInformationToType(v.valueInformation, project)
+      case _ => throw new RuntimeException("Unknown expression: " + expr)
+    }
+
+    throw new RuntimeException("Cannot compute type for expression: " + expr)
+  }
 
   def valueInformationToType(value: ValueInformation, project: Project[_]): Type = {
     if (value.isPrimitiveValue) {

--- a/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalVal.scala
+++ b/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalVal.scala
@@ -25,16 +25,7 @@ class OpalVal(
     unbalanced: ControlFlowGraph.Edge = null
 ) extends Val(method, unbalanced) {
 
-  override def getType: Type = delegate match {
-    case v: TacLocal => OpalType.valueInformationToType(v.valueInformation, method.project)
-    case nullExpr: NullExpr => new OpalType(nullExpr.tpe, method.project)
-    case const: Const => new OpalType(const.tpe, method.project)
-    case newExpr: New => new OpalType(newExpr.tpe, method.project)
-    case newArrayExpr: NewArray[_] => new OpalType(newArrayExpr.tpe, method.project)
-    case functionCall: FunctionCall[_] =>
-      new OpalType(functionCall.descriptor.returnType, method.project)
-    case _ => throw new RuntimeException("Type not implemented yet")
-  }
+  override def getType: Type = OpalType.getTypeForExpr(delegate, method.project)
 
   override def isStatic: Boolean = false
 

--- a/idealPDS/src/main/java/typestate/TransitionFunctionImpl.java
+++ b/idealPDS/src/main/java/typestate/TransitionFunctionImpl.java
@@ -18,8 +18,6 @@ import static typestate.TransitionFunctionOne.one;
 import static typestate.TransitionFunctionZero.zero;
 
 import boomerang.scope.ControlFlowGraph.Edge;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -31,6 +29,7 @@ import typestate.finiteautomata.TransitionImpl;
 import wpds.impl.Weight;
 
 public class TransitionFunctionImpl implements TransitionFunction {
+
   @NonNull private final Set<? extends Transition> values;
   @NonNull private final Set<Edge> stateChangeStatements;
 
@@ -48,7 +47,7 @@ public class TransitionFunctionImpl implements TransitionFunction {
   @Override
   @NonNull
   public Collection<Transition> getValues() {
-    return Lists.newArrayList(values);
+    return new HashSet<>(values);
   }
 
   @NonNull
@@ -92,19 +91,27 @@ public class TransitionFunctionImpl implements TransitionFunction {
   @Override
   public Weight combineWith(@NonNull Weight other) {
     if (!(other instanceof TransitionFunction)) {
-      throw new RuntimeException();
+      throw new RuntimeException("Cannot combine TransitionFunction with non TransitionFunction");
     }
+
     if (other == zero()) {
       return this;
     }
-    TransitionFunctionOne one = one();
-    if (other == one) {
-      return one;
+
+    if (other == one()) {
+      Set<Transition> transitions = new HashSet<>();
+
+      for (Transition t : values) {
+        transitions.add(new TransitionImpl(t.from(), t.to()));
+      }
+
+      return new TransitionFunctionImpl(transitions, stateChangeStatements);
     }
+
     TransitionFunction func = (TransitionFunction) other;
     Set<Transition> transitions = new HashSet<>(func.getValues());
     transitions.addAll(values);
-    HashSet<Edge> newStateChangeStmts = Sets.newHashSet(stateChangeStatements);
+    Set<Edge> newStateChangeStmts = new HashSet<>(stateChangeStatements);
     newStateChangeStmts.addAll(func.getStateChangeStatements());
     return new TransitionFunctionImpl(transitions, newStateChangeStmts);
   }

--- a/idealPDS/src/main/java/typestate/TransitionFunctionImpl.java
+++ b/idealPDS/src/main/java/typestate/TransitionFunctionImpl.java
@@ -21,6 +21,7 @@ import boomerang.scope.ControlFlowGraph.Edge;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import org.jspecify.annotations.NonNull;
 import typestate.finiteautomata.Transition;
@@ -99,12 +100,12 @@ public class TransitionFunctionImpl implements TransitionFunction {
     }
 
     if (other == one()) {
-      Set<Transition> transitions = new HashSet<>();
-
-      for (Transition t : values) {
-        transitions.add(new TransitionImpl(t.from(), t.to()));
+      Set<Transition> transitions = new HashSet<>(values);
+      Set<Transition> idTransitions = new HashSet<>();
+      for (Transition t : transitions) {
+        idTransitions.add(new TransitionImpl(t.from(), t.from()));
       }
-
+      transitions.addAll(idTransitions);
       return new TransitionFunctionImpl(transitions, stateChangeStatements);
     }
 
@@ -116,27 +117,21 @@ public class TransitionFunctionImpl implements TransitionFunction {
     return new TransitionFunctionImpl(transitions, newStateChangeStmts);
   }
 
-  public String toString() {
-    return "Weight: " + values;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TransitionFunctionImpl that = (TransitionFunctionImpl) o;
+    return Objects.equals(values, that.values);
   }
 
   @Override
   public int hashCode() {
-    return values.hashCode();
+    return Objects.hash(values);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    TransitionFunctionImpl other = (TransitionFunctionImpl) obj;
-    return values.equals(other.values);
+  public String toString() {
+    return "Weight: " + values;
   }
 }


### PR DESCRIPTION
- When combining `TransitionFunctionImpl` with `ONE`, it always returns `ONE` and not the TransitionFunctionImpl (`ONE` should act as an identity
- Use a factory to determine the types of Opal expressions. Currently, some expressions were missing