### PR TITLE
Add option to create an OpalVal in Java

### DIFF
--- a/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalVal.scala
+++ b/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalVal.scala
@@ -171,3 +171,16 @@ class OpalVal(
 
   override def toString: String = s"$getVariableName${if (isUnbalanced) " unbalanced " + unbalancedStmt else ""}"
 }
+
+object OpalVal {
+
+  /**
+   * Creates an [[OpalVal]] from an arbitrary expression. Note that the generic type is cast to [[TacLocal]].
+   * Hence, the expression should align with this Boomerang scope.
+   *
+   * @param expr the expression to wrap
+   * @param method the method from the expression
+   * @return the [[OpalVal]] wrapper for the expression
+   */
+  def createUnsafe(expr: Expr[_], method: OpalMethod) = new OpalVal(expr.asInstanceOf[Expr[TacLocal]], method)
+}


### PR DESCRIPTION
Currently, it is not possible to create an `OpalVal` in a Java program because we enforce a generic type on the underlying expression. Since Java does not understand Scala's generic type system, one must use explicit types `Expr[TacLocal]` and cannot use something like `Expr[Nothing]`. To deal with this problem, this PR adds an "unsafe" way that allows to ignore the generic type in Java programs by doing the cast in the Scala program