### PR TITLE
Add flow functions that support method chaining

### DIFF
--- a/idealPDS/src/main/java/typestate/ChainingBackwardFlowFunction.java
+++ b/idealPDS/src/main/java/typestate/ChainingBackwardFlowFunction.java
@@ -1,0 +1,65 @@
+/**
+ * ***************************************************************************** 
+ * Copyright (c) 2018 Fraunhofer IEM, Paderborn, Germany
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ * <p>
+ * Contributors:
+ *   Johannes Spaeth - initial API and implementation
+ * *****************************************************************************
+ */
+package typestate;
+
+import boomerang.flowfunction.DefaultBackwardFlowFunction;
+import boomerang.options.IAllocationSite;
+import boomerang.scope.ControlFlowGraph;
+import boomerang.scope.DeclaredMethod;
+import boomerang.scope.InvokeExpr;
+import boomerang.scope.Statement;
+import boomerang.scope.Val;
+import boomerang.solver.Strategies;
+import boomerang.utils.MethodWrapper;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import sync.pds.solver.nodes.Node;
+import wpds.interfaces.State;
+
+public class ChainingBackwardFlowFunction extends DefaultBackwardFlowFunction {
+
+  private final Collection<MethodWrapper> methodChains;
+
+  public ChainingBackwardFlowFunction(
+      IAllocationSite allocationSite,
+      Strategies strategies,
+      Collection<MethodWrapper> methodChains) {
+    super(allocationSite, strategies);
+
+    this.methodChains = methodChains;
+  }
+
+  @Override
+  public Collection<State> callToReturnFlow(
+      ControlFlowGraph.Edge currEdge, ControlFlowGraph.Edge nextEdge, Val fact) {
+    Collection<State> out = new LinkedHashSet<>(super.callToReturnFlow(currEdge, nextEdge, fact));
+
+    Statement statement = nextEdge.getTarget();
+    if (statement.isAssignStmt() && statement.containsInvokeExpr()) {
+      InvokeExpr invokeExpr = statement.getInvokeExpr();
+      DeclaredMethod declaredMethod = invokeExpr.getDeclaredMethod();
+
+      if (methodChains.contains(declaredMethod.toMethodWrapper())) {
+        Val leftOp = statement.getLeftOp();
+
+        if (leftOp.equals(fact) && invokeExpr.isInstanceInvokeExpr()) {
+          out.add(new Node<>(nextEdge, invokeExpr.getBase()));
+        }
+      }
+    }
+
+    return out;
+  }
+}

--- a/idealPDS/src/main/java/typestate/ChainingFlowFunctionFactory.java
+++ b/idealPDS/src/main/java/typestate/ChainingFlowFunctionFactory.java
@@ -1,0 +1,75 @@
+/**
+ * ***************************************************************************** 
+ * Copyright (c) 2018 Fraunhofer IEM, Paderborn, Germany
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ * <p>
+ * Contributors:
+ *   Johannes Spaeth - initial API and implementation
+ * *****************************************************************************
+ */
+package typestate;
+
+import boomerang.flowfunction.DefaultFlowFunctionFactory;
+import boomerang.flowfunction.IBackwardFlowFunction;
+import boomerang.flowfunction.IForwardFlowFunction;
+import boomerang.options.BoomerangOptions;
+import boomerang.scope.FrameworkScope;
+import boomerang.solver.BackwardBoomerangSolver;
+import boomerang.solver.ForwardBoomerangSolver;
+import boomerang.solver.Strategies;
+import boomerang.utils.MethodWrapper;
+import java.util.Collection;
+
+/**
+ * Flow function factory that extends the {@link DefaultFlowFunctionFactory} by adding features to
+ * deal with chained methods when applying the call-to-return flow. Intermediate representations
+ * transform chained method calls into multiple statements and introduce new locals for each
+ * intermediate call. Although the chained calls return the original objects (i.e. an alias), the
+ * default flow function do not find the aliases. The extension in this flow function factory adds
+ * the functionality to collect corresponding aliases, too.
+ *
+ * <p>For example, a program
+ *
+ * <pre>{@code
+ * l.chain().chain();
+ * }</pre>
+ *
+ * is transformed into the intermediate representation
+ *
+ * <pre>{@code
+ * $s0 = l.chain();
+ * $s1 = $s0.chain();
+ * }</pre>
+ *
+ * The extended flow functions make sure to collect $s0 and $s1 as alias s.t. the analysis can
+ * collect the second call to chain().
+ */
+public class ChainingFlowFunctionFactory extends DefaultFlowFunctionFactory {
+
+  private final Collection<MethodWrapper> methodChains;
+
+  public ChainingFlowFunctionFactory(Collection<MethodWrapper> methodChains) {
+    this.methodChains = methodChains;
+  }
+
+  @Override
+  public IForwardFlowFunction createForwardFlowFunction(
+      FrameworkScope frameworkScope, BoomerangOptions options, ForwardBoomerangSolver<?> solver) {
+    Strategies strategies = createStrategies(frameworkScope, options, solver);
+
+    return new ChainingForwardFlowFunction(strategies, methodChains);
+  }
+
+  @Override
+  public IBackwardFlowFunction createBackwardFlowFunction(
+      FrameworkScope frameworkScope, BoomerangOptions options, BackwardBoomerangSolver<?> solver) {
+    Strategies strategies = createStrategies(frameworkScope, options, solver);
+
+    return new ChainingBackwardFlowFunction(options.allocationSite(), strategies, methodChains);
+  }
+}

--- a/idealPDS/src/main/java/typestate/ChainingForwardFlowFunction.java
+++ b/idealPDS/src/main/java/typestate/ChainingForwardFlowFunction.java
@@ -1,0 +1,68 @@
+/**
+ * ***************************************************************************** 
+ * Copyright (c) 2018 Fraunhofer IEM, Paderborn, Germany
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ * <p>
+ * Contributors:
+ *   Johannes Spaeth - initial API and implementation
+ * *****************************************************************************
+ */
+package typestate;
+
+import boomerang.ForwardQuery;
+import boomerang.flowfunction.DefaultForwardFlowFunction;
+import boomerang.scope.ControlFlowGraph;
+import boomerang.scope.DeclaredMethod;
+import boomerang.scope.InvokeExpr;
+import boomerang.scope.Statement;
+import boomerang.scope.Val;
+import boomerang.solver.Strategies;
+import boomerang.utils.MethodWrapper;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import sync.pds.solver.nodes.Node;
+import wpds.interfaces.State;
+
+public class ChainingForwardFlowFunction extends DefaultForwardFlowFunction {
+
+  private final Collection<MethodWrapper> methodChains;
+
+  public ChainingForwardFlowFunction(
+      Strategies strategies, Collection<MethodWrapper> methodChains) {
+    super(strategies);
+
+    this.methodChains = methodChains;
+  }
+
+  @Override
+  public Collection<State> callToReturnFlow(
+      ForwardQuery query, ControlFlowGraph.Edge edge, Val fact) {
+    Collection<State> out = new LinkedHashSet<>(super.callToReturnFlow(query, edge, fact));
+
+    Statement statement = edge.getStart();
+    if (statement.isAssignStmt() && statement.containsInvokeExpr()) {
+      InvokeExpr invokeExpr = statement.getInvokeExpr();
+      DeclaredMethod declaredMethod = invokeExpr.getDeclaredMethod();
+
+      if (methodChains.contains(declaredMethod.toMethodWrapper())) {
+        /* If the current statement is a chained method call, consider it as an alias and
+         * continue the propagation with the implicitly defined local
+         */
+        if (invokeExpr.isInstanceInvokeExpr()) {
+          Val base = invokeExpr.getBase();
+
+          if (base.equals(fact)) {
+            out.add(new Node<>(edge, statement.getLeftOp()));
+          }
+        }
+      }
+    }
+
+    return out;
+  }
+}

--- a/idealPDS/src/test/java/chains/Chain.java
+++ b/idealPDS/src/test/java/chains/Chain.java
@@ -12,27 +12,15 @@
  *   Johannes Spaeth - initial API and implementation
  * *****************************************************************************
  */
-package test;
+package chains;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public class Chain {
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface TestConfig {
-
-  enum FlowFunctions {
-    DEFAULT,
-    CHAINING
+  public Chain chain1() {
+    return this;
   }
 
-  Class<?> stateMachine();
-
-  Class<?>[] includedClasses() default {};
-
-  Class<?>[] excludedClasses() default {};
-
-  FlowFunctions flowFunctions() default FlowFunctions.DEFAULT;
+  public Chain chain2() {
+    return this;
+  }
 }

--- a/idealPDS/src/test/java/chains/ChainStateMachine.java
+++ b/idealPDS/src/test/java/chains/ChainStateMachine.java
@@ -1,0 +1,101 @@
+/**
+ * ***************************************************************************** 
+ * Copyright (c) 2018 Fraunhofer IEM, Paderborn, Germany
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ * <p>
+ * Contributors:
+ *   Johannes Spaeth - initial API and implementation
+ * *****************************************************************************
+ */
+package chains;
+
+import boomerang.WeightedForwardQuery;
+import boomerang.scope.ControlFlowGraph;
+import java.util.Collection;
+import java.util.Collections;
+import typestate.TransitionFunction;
+import typestate.finiteautomata.MatcherTransition;
+import typestate.finiteautomata.State;
+import typestate.finiteautomata.TypeStateMachineWeightFunctions;
+
+public class ChainStateMachine extends TypeStateMachineWeightFunctions {
+
+  public enum States implements State {
+    INIT,
+    CHAIN1,
+    CHAIN2;
+
+    @Override
+    public boolean isErrorState() {
+      return this != CHAIN2;
+    }
+
+    @Override
+    public boolean isInitialState() {
+      return this == INIT;
+    }
+
+    @Override
+    public boolean isAccepting() {
+      return this == CHAIN2;
+    }
+  }
+
+  public ChainStateMachine() {
+    addTransition(
+        new MatcherTransition(
+            States.INIT,
+            ".*chain1.*",
+            MatcherTransition.Parameter.This,
+            States.CHAIN1,
+            MatcherTransition.Type.OnCallToReturn));
+    addTransition(
+        new MatcherTransition(
+            States.CHAIN1,
+            ".chain1.*",
+            MatcherTransition.Parameter.This,
+            States.CHAIN1,
+            MatcherTransition.Type.OnCallToReturn));
+    addTransition(
+        new MatcherTransition(
+            States.CHAIN1,
+            ".*chain2.*",
+            MatcherTransition.Parameter.This,
+            States.CHAIN2,
+            MatcherTransition.Type.OnCallToReturn));
+    addTransition(
+        new MatcherTransition(
+            States.CHAIN2,
+            ".chain1.*",
+            MatcherTransition.Parameter.This,
+            States.CHAIN1,
+            MatcherTransition.Type.OnCallToReturn));
+    addTransition(
+        new MatcherTransition(
+            States.CHAIN2,
+            ".chain2.*",
+            MatcherTransition.Parameter.This,
+            States.CHAIN2,
+            MatcherTransition.Type.OnCallToReturn));
+  }
+
+  @Override
+  public Collection<WeightedForwardQuery<TransitionFunction>> generateSeed(
+      ControlFlowGraph.Edge stmt) {
+    try {
+      return generateAtAllocationSiteOf(stmt, Class.forName(Chain.class.getName()));
+    } catch (ClassNotFoundException e) {
+      return Collections.emptySet();
+    }
+  }
+
+  @Override
+  protected State initialState() {
+    return States.INIT;
+  }
+}

--- a/idealPDS/src/test/java/chains/ChainingTestFlowFunctionFactory.java
+++ b/idealPDS/src/test/java/chains/ChainingTestFlowFunctionFactory.java
@@ -12,27 +12,18 @@
  *   Johannes Spaeth - initial API and implementation
  * *****************************************************************************
  */
-package test;
+package chains;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import boomerang.utils.MethodWrapper;
+import java.util.Set;
+import typestate.ChainingFlowFunctionFactory;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface TestConfig {
+public class ChainingTestFlowFunctionFactory extends ChainingFlowFunctionFactory {
 
-  enum FlowFunctions {
-    DEFAULT,
-    CHAINING
+  public ChainingTestFlowFunctionFactory() {
+    super(
+        Set.of(
+            new MethodWrapper(Chain.class.getName(), "chain1", Chain.class.getName()),
+            new MethodWrapper(Chain.class.getName(), "chain2", Chain.class.getName())));
   }
-
-  Class<?> stateMachine();
-
-  Class<?>[] includedClasses() default {};
-
-  Class<?>[] excludedClasses() default {};
-
-  FlowFunctions flowFunctions() default FlowFunctions.DEFAULT;
 }

--- a/idealPDS/src/test/java/chains/MethodChainingTest.java
+++ b/idealPDS/src/test/java/chains/MethodChainingTest.java
@@ -1,0 +1,108 @@
+/**
+ * ***************************************************************************** 
+ * Copyright (c) 2018 Fraunhofer IEM, Paderborn, Germany
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ * <p>
+ * Contributors:
+ *   Johannes Spaeth - initial API and implementation
+ * *****************************************************************************
+ */
+package chains;
+
+import assertions.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import test.IDEALTestRunnerInterceptor;
+import test.TestConfig;
+import test.TestParameters;
+
+@ExtendWith(IDEALTestRunnerInterceptor.class)
+@TestConfig(
+    stateMachine = ChainStateMachine.class,
+    excludedClasses = {Chain.class},
+    flowFunctions = TestConfig.FlowFunctions.CHAINING)
+public class MethodChainingTest {
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void noChainingTest1() {
+    Chain chain = new Chain();
+    chain.chain1();
+
+    Assertions.mustBeInErrorState(chain);
+  }
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void chainingTest1() {
+    Chain chain = new Chain();
+    chain.chain1();
+
+    Assertions.mustBeInErrorState(chain);
+  }
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void noChainingTest2() {
+    Chain chain = new Chain();
+    chain.chain1();
+    chain.chain2();
+
+    Assertions.mustBeInAcceptingState(chain);
+  }
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void chainingTest2() {
+    Chain chain = new Chain();
+    chain.chain1().chain2();
+
+    Assertions.mustBeInAcceptingState(chain);
+  }
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void noChainingTest3() {
+    Chain chain = new Chain();
+    chain.chain1();
+    chain.chain1();
+    chain.chain2();
+
+    Assertions.mustBeInAcceptingState(chain);
+  }
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void chainingTest3() {
+    Chain chain = new Chain();
+    chain.chain1().chain1().chain2();
+
+    Assertions.mustBeInAcceptingState(chain);
+  }
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void noChainingTest4() {
+    Chain chain = new Chain();
+    chain.chain1();
+    chain.chain1();
+    chain.chain2();
+    chain.chain1();
+
+    Assertions.mustBeInErrorState(chain);
+  }
+
+  @Test
+  @TestParameters(expectedSeedCount = 1, expectedAssertionCount = 1)
+  public void chainingTest4() {
+    Chain chain = new Chain();
+    chain.chain1().chain1().chain2().chain1();
+
+    Assertions.mustBeInErrorState(chain);
+  }
+}

--- a/idealPDS/src/test/java/test/IDEALTestRunnerInterceptor.java
+++ b/idealPDS/src/test/java/test/IDEALTestRunnerInterceptor.java
@@ -14,6 +14,11 @@
  */
 package test;
 
+import boomerang.flowfunction.DefaultFlowFunctionFactory;
+import boomerang.flowfunction.IFlowFunctionFactory;
+import boomerang.options.BoomerangOptions;
+import boomerang.solver.Strategies;
+import chains.ChainingTestFlowFunctionFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -32,6 +37,7 @@ public class IDEALTestRunnerInterceptor
     implements BeforeAllCallback, InvocationInterceptor, AfterEachCallback {
 
   private IDEALTestingFramework testingFramework;
+  private BoomerangOptions options;
 
   @Override
   public void beforeAll(ExtensionContext context) {
@@ -78,6 +84,7 @@ public class IDEALTestRunnerInterceptor
             .map(Class::getName)
             .collect(Collectors.toList());
     testingFramework = new IDEALTestingFramework(stateMachine, includedClasses, excludedClasses);
+    options = createOptions(testConfig);
   }
 
   @Override
@@ -97,7 +104,7 @@ public class IDEALTestRunnerInterceptor
               + "' in class '"
               + testClassName
               + "' is not annotated with '"
-              + TestConfig.class.getSimpleName()
+              + TestParameters.class.getSimpleName()
               + "'");
     }
 
@@ -111,17 +118,39 @@ public class IDEALTestRunnerInterceptor
         testClassName,
         testMethodName,
         parameters.expectedSeedCount(),
-        parameters.expectedAssertionCount());
+        parameters.expectedAssertionCount(),
+        options);
 
     try {
       invocation.proceed();
     } catch (Throwable ignored) {
-
     }
   }
 
   @Override
   public void afterEach(ExtensionContext context) {
     testingFramework.cleanUp();
+  }
+
+  private BoomerangOptions createOptions(TestConfig config) {
+    IFlowFunctionFactory factory = getFlowFunctionFactory(config.flowFunctions());
+
+    return BoomerangOptions.builder()
+        .withFlowFunctionFactory(factory)
+        .withStaticFieldStrategy(Strategies.StaticFieldStrategy.FLOW_SENSITIVE)
+        .withAnalysisTimeout(-1)
+        .enableAllowMultipleQueries(true)
+        .build();
+  }
+
+  private IFlowFunctionFactory getFlowFunctionFactory(TestConfig.FlowFunctions flowFunctions) {
+    switch (flowFunctions) {
+      case DEFAULT:
+        return new DefaultFlowFunctionFactory();
+      case CHAINING:
+        return new ChainingTestFlowFunctionFactory();
+      default:
+        throw new RuntimeException("Unknown FlowFunctions: " + flowFunctions);
+    }
   }
 }

--- a/idealPDS/src/test/java/test/IDEALTestingFramework.java
+++ b/idealPDS/src/test/java/test/IDEALTestingFramework.java
@@ -30,7 +30,6 @@ import boomerang.scope.InvokeExpr;
 import boomerang.scope.Method;
 import boomerang.scope.Statement;
 import boomerang.scope.Val;
-import boomerang.solver.Strategies;
 import boomerang.utils.MethodWrapper;
 import ideal.IDEALAnalysis;
 import ideal.IDEALAnalysisDefinition;
@@ -61,7 +60,11 @@ public class IDEALTestingFramework extends TestingFramework {
   }
 
   public void analyze(
-      String targetClassName, String targetMethodName, int expectedSeeds, int expectedAssertions) {
+      String targetClassName,
+      String targetMethodName,
+      int expectedSeeds,
+      int expectedAssertions,
+      BoomerangOptions options) {
     LOGGER.info(
         "Running '{}' in class '{}' with {} assertions",
         targetMethodName,
@@ -87,7 +90,8 @@ public class IDEALTestingFramework extends TestingFramework {
 
     // Run IDEal
     StoreIDEALResultHandler<TransitionFunction> resultHandler = new StoreIDEALResultHandler<>();
-    IDEALAnalysis<TransitionFunction> idealAnalysis = createAnalysis(frameworkScope, resultHandler);
+    IDEALAnalysis<TransitionFunction> idealAnalysis =
+        createAnalysis(frameworkScope, resultHandler, options);
     idealAnalysis.run();
 
     // Update results
@@ -107,7 +111,9 @@ public class IDEALTestingFramework extends TestingFramework {
   }
 
   protected IDEALAnalysis<TransitionFunction> createAnalysis(
-      FrameworkScope frameworkScope, StoreIDEALResultHandler<TransitionFunction> resultHandler) {
+      FrameworkScope frameworkScope,
+      StoreIDEALResultHandler<TransitionFunction> resultHandler,
+      BoomerangOptions options) {
     return new IDEALAnalysis<>(
         new IDEALAnalysisDefinition<>() {
 
@@ -131,11 +137,7 @@ public class IDEALTestingFramework extends TestingFramework {
 
           @Override
           public BoomerangOptions boomerangOptions() {
-            return BoomerangOptions.builder()
-                .withStaticFieldStrategy(Strategies.StaticFieldStrategy.FLOW_SENSITIVE)
-                .withAnalysisTimeout(-1)
-                .enableAllowMultipleQueries(true)
-                .build();
+            return options;
           }
 
           @Override


### PR DESCRIPTION
Add flow functions that extend the default flow function by including locals that are implicitly defined by chained method calls in the alias analysis, too