### PR TITLE
Make the behavior of OpalWrappedClass.getMethods consistent

### DIFF
--- a/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalWrappedClass.scala
+++ b/boomerangScope-Opal/src/main/scala/boomerang/scope/opal/tac/OpalWrappedClass.scala
@@ -25,19 +25,17 @@ import org.opalj.br.analyses.Project
 class OpalWrappedClass(val delegate: ClassType, project: Project[_]) extends WrappedClass {
 
   override def getMethods: util.Set[Method] = {
+    val methods = new util.HashSet[Method]
     val classFile = project.classFile(delegate)
 
     if (classFile.isDefined) {
-      val methods = new util.HashSet[Method]
-
-      classFile.get.methods.foreach(method => {
-        methods.add(OpalMethod.of(method, project))
-      })
-
-      return methods
+      classFile.get.methods
+        .filter(!_.body.isEmpty)
+        .foreach(method => {
+          methods.add(OpalMethod.of(method, project))
+        })
     }
-
-    throw new RuntimeException("Class file of class not available: " + delegate.fqn)
+    return methods
   }
 
   override def hasSuperclass: Boolean = {

--- a/boomerangScope-Opal/src/test/scala/boomerang/scope/opal/OpalWrappedClassTest.scala
+++ b/boomerangScope-Opal/src/test/scala/boomerang/scope/opal/OpalWrappedClassTest.scala
@@ -1,0 +1,40 @@
+/**
+ * ***************************************************************************** 
+ * Copyright (c) 2018 Fraunhofer IEM, Paderborn, Germany
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ * <p>
+ * Contributors:
+ *   Johannes Spaeth - initial API and implementation
+ * *****************************************************************************
+ */
+package boomerang.scope.opal
+
+import boomerang.scope.opal.tac.OpalWrappedClass
+import boomerang.scope.test.targets.AbstractClass
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.opalj.br.ClassType
+
+class OpalWrappedClassTest {
+
+  @Test
+  def testGetMethodsAbstractClass(): Unit = {
+    val opalSetup = new OpalSetup
+    opalSetup.setupOpal(classOf[AbstractClass].getName)
+    val wrappedClass = new OpalWrappedClass(opalSetup.targetClass.get.thisType, opalSetup.project.get)
+    Assertions.assertEquals(2, wrappedClass.getMethods.size)
+  }
+
+  @Test
+  def testGetMethodsForClassTypeThatIsNotPartOfTheProject(): Unit = {
+    val opalSetup = new OpalSetup
+    opalSetup.setupOpal("Some Dummy Value")
+    val wrappedClass = new OpalWrappedClass(ClassType.Object, opalSetup.project.get)
+    Assertions.assertEquals(0, wrappedClass.getMethods.size)
+  }
+}

--- a/boomerangScope/src/test/java/boomerang/scope/test/targets/AbstractClass.java
+++ b/boomerangScope/src/test/java/boomerang/scope/test/targets/AbstractClass.java
@@ -1,0 +1,24 @@
+/**
+ * ***************************************************************************** 
+ * Copyright (c) 2018 Fraunhofer IEM, Paderborn, Germany
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * <p>
+ * SPDX-License-Identifier: EPL-2.0
+ * <p>
+ * Contributors:
+ *   Johannes Spaeth - initial API and implementation
+ * *****************************************************************************
+ */
+package boomerang.scope.test.targets;
+
+public abstract class AbstractClass {
+
+  public AbstractClass() {}
+
+  public abstract void foo();
+
+  public void bar() {}
+}


### PR DESCRIPTION
```
    Make the behavior of OpalWrappedClass.getMethods consistent
    
    The current behavior of OpalWrappedClass.getMethods is inconsistent wrt.
    JimpleUpWrappedClass.getMethods and JimpleWrappedClass.getMethods:
    - In case of a class, which is not part of the project,
      OpalWrappedClass.getMethods throws an exception, while, for instance,
      JimpleUpWrappedClass.getMethods returns an empty set.
    - If the wrapped class has a method with an empty body (for instance,
      an abstract method), OpalWrappedClass.getMethods throws an exception
      (which is clearly a bug). Instead, methods with an empty body should
      be ignored (that's consistent to the getMethods implementation in
      JimpleUpWrappedClass and JimpleWrappedClass).
    
    The OpalWrappedClassTest documents the new behavior of
    JimpleUpWrappedClass.getMethods.
```