### PR TITLE
[minor] Release 4.4.0

### DIFF
--- a/PDS/pom.xml
+++ b/PDS/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>PDS</artifactId>

--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>synchronizedPDS</artifactId>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>WPDS</artifactId>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>boomerangPDS</artifactId>

--- a/boomerangScope-Opal/pom.xml
+++ b/boomerangScope-Opal/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
     </parent>
 
     <artifactId>boomerangScope-Opal</artifactId>

--- a/boomerangScope-Soot/pom.xml
+++ b/boomerangScope-Soot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>boomerangScope-Soot</artifactId>

--- a/boomerangScope-SootUp/pom.xml
+++ b/boomerangScope-SootUp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/boomerangScope-WALA/pom.xml
+++ b/boomerangScope-WALA/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>BoomerangScope-WALA</artifactId>

--- a/boomerangScope/pom.xml
+++ b/boomerangScope/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>boomerangScope</artifactId>

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>idealPDS</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.fraunhofer.iem</groupId>
     <artifactId>Boomerang-Parent</artifactId>
-    <version>4.3.3-SNAPSHOT</version>
+    <version>4.4.0</version>
     <packaging>pom</packaging>
     <name>Boomerang-Parent</name>
     <description>Parent project that holds all definitions for Synchronized and Weighted Pushdown Systems, Boomerang, and IDEal</description>

--- a/testCore/pom.xml
+++ b/testCore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.fraunhofer.iem</groupId>
         <artifactId>Boomerang-Parent</artifactId>
-        <version>4.3.3-SNAPSHOT</version>
+        <version>4.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>testCore</artifactId>


### PR DESCRIPTION
Release candidate for `4.4.0`.

To change the release type, edit the title's `[minor]` tag to `[major]`, `[minor]` or `[patch]` - the version and this branch update automatically.

**This PR must be merged manually.** Merging it tags `4.4.0` (adjusted if you edited the type tag), deploys to Maven Central, and opens a follow-up PR advancing `develop` to the next SNAPSHOT (that one auto-merges).