### PR TITLE
Cache weight tables

### DIFF
--- a/WPDS/src/main/java/wpds/impl/WeightedPAutomaton.java
+++ b/WPDS/src/main/java/wpds/impl/WeightedPAutomaton.java
@@ -79,6 +79,13 @@ public abstract class WeightedPAutomaton<N extends Location, D extends State, W 
   private final Set<UnbalancedPopListener<N, D, W>> unbalancedPopListeners = new LinkedHashSet<>();
   private final Map<UnbalancedPopEntry, W> unbalancedPops = Maps.newHashMap();
   private final Map<Transition<N, D>, W> transitionsToFinalWeights = Maps.newHashMap();
+
+  /**
+   * Incremented whenever {@link #transitionsToFinalWeights} actually changes. Callers that derive a
+   * view of the final weights can cache that view and compare this counter to detect that their
+   * snapshot went stale, instead of rebuilding it on every access.
+   */
+  private int finalWeightsVersion = 0;
   private ForwardDFSVisitor<N, D, W> dfsVisitor;
   private ForwardDFSVisitor<N, D, W> dfsEpsVisitor;
   public int failedAdditions;
@@ -625,6 +632,16 @@ public abstract class WeightedPAutomaton<N extends Location, D extends State, W 
     }
   }
 
+  /**
+   * A version counter for {@link #getTransitionsToFinalWeights()}. It changes exactly when the
+   * final weights change, so a derived view captured together with this value stays valid for as
+   * long as the value does. Read it <em>after</em> {@link #getTransitionsToFinalWeights()}, which
+   * may itself compute weights on its first call.
+   */
+  public int getFinalWeightsVersion() {
+    return finalWeightsVersion;
+  }
+
   public Map<Transition<N, D>, W> getTransitionsToFinalWeights() {
     LOGGER.trace("Start computing final weights");
     final Stopwatch w = Stopwatch.createStarted();
@@ -652,7 +669,10 @@ public abstract class WeightedPAutomaton<N extends Location, D extends State, W 
       W newWeight = (W) weight.extendWith(w);
       W weightAtTarget = transitionsToFinalWeights.get(t);
       W newVal = (weightAtTarget == null ? newWeight : (W) weightAtTarget.combineWith(newWeight));
-      transitionsToFinalWeights.put(t, newVal);
+      if (!newVal.equals(weightAtTarget)) {
+        transitionsToFinalWeights.put(t, newVal);
+        finalWeightsVersion++;
+      }
       if (isGeneratedState(t.getStart())) {
         registerListener(new ValueComputationListener(t.getStart(), newVal));
       }

--- a/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
+++ b/boomerangPDS/src/main/java/boomerang/solver/AbstractBoomerangSolver.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -97,6 +98,10 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
   protected final DataFlowScope dataFlowScope;
   protected final BoomerangOptions options;
   protected final Type type;
+  private Table<Edge, Val, W> edgeValWeightTable;
+  private int edgeValWeightTableVersion;
+  private Table<Statement, Val, W> statementValWeightTable;
+  private int statementValWeightTableVersion;
 
   public AbstractBoomerangSolver(
       ObservableICFG<Statement, Method> icfg,
@@ -239,11 +244,15 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
   }
 
   public Table<Edge, Val, W> asEdgeValWeightTable() {
-    final Table<Edge, Val, W> results = HashBasedTable.create();
-
     WeightedPAutomaton<Edge, INode<Val>, W> callAut = getCallAutomaton();
-    for (Entry<Transition<Edge, INode<Val>>, W> e :
-        callAut.getTransitionsToFinalWeights().entrySet()) {
+    Map<Transition<Edge, INode<Val>>, W> finalWeights = callAut.getTransitionsToFinalWeights();
+    int version = callAut.getFinalWeightsVersion();
+    if (edgeValWeightTable != null && edgeValWeightTableVersion == version) {
+      return edgeValWeightTable;
+    }
+
+    final Table<Edge, Val, W> results = HashBasedTable.create();
+    for (Entry<Transition<Edge, INode<Val>>, W> e : finalWeights.entrySet()) {
       Transition<Edge, INode<Val>> t = e.getKey();
       W w = e.getValue();
       if (t.getLabel().equals(ControlFlowGraph.Edge.epsilon())) continue;
@@ -251,15 +260,22 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
           && !t.getLabel().getMethod().equals(t.getStart().fact().m())) continue;
       results.put(t.getLabel(), t.getStart().fact(), w);
     }
-    return results;
+
+    edgeValWeightTable = Tables.unmodifiableTable(results);
+    edgeValWeightTableVersion = version;
+    return edgeValWeightTable;
   }
 
   public Table<Statement, Val, W> asStatementValWeightTable() {
-    Table<Statement, Val, W> results = HashBasedTable.create();
-
     WeightedPAutomaton<Edge, INode<Val>, W> callAut = getCallAutomaton();
-    for (Entry<Transition<Edge, INode<Val>>, W> e :
-        callAut.getTransitionsToFinalWeights().entrySet()) {
+    Map<Transition<Edge, INode<Val>>, W> finalWeights = callAut.getTransitionsToFinalWeights();
+    int version = callAut.getFinalWeightsVersion();
+    if (statementValWeightTable != null && statementValWeightTableVersion == version) {
+      return statementValWeightTable;
+    }
+
+    Table<Statement, Val, W> results = HashBasedTable.create();
+    for (Entry<Transition<Edge, INode<Val>>, W> e : finalWeights.entrySet()) {
       Transition<Edge, INode<Val>> t = e.getKey();
       W w = e.getValue();
 
@@ -274,7 +290,9 @@ public abstract class AbstractBoomerangSolver<W extends Weight>
       }
     }
 
-    return results;
+    statementValWeightTable = Tables.unmodifiableTable(results);
+    statementValWeightTableVersion = version;
+    return statementValWeightTable;
   }
 
   protected void addPotentialUnbalancedFlow(


### PR DESCRIPTION

**Time**

|                                    | before  | after |
| ---------------------------------- | ------- | ----- |
| wall clock                         | 3894 s  | 99 s  |
| main-thread samples                | 180 208 | 2 804 |
| under the weight tables            | 97.1 %  | 4.9 % |
| in `JimpleUpStatement` hash/equals | 73.0 %  | 4.6 % |

Without a profiler attached, the same analysis goes from **1187 s to 41 s**.

**Memory**

|                                 | before   | after  |
| ------------------------------- | -------- | ------ |
| total allocated                 | 265.3 GB | 6.9 GB |
| GC events for the same analysis | 1142     | 57     |
| mean heap in use                | 728 MB   | 323 MB |
| mean live set after GC          | 564 MB   | 235 MB |
| peak live set after GC          | 762 MB   | 777 MB |

Peak footprint is unchanged: the cache retains one table per solver instead of building and
discarding one per query, so it removes churn rather than adding residency. The 38x drop in
total allocation is the tables that are no longer rebuilt.

Small workloads are unaffected (a ~30 s single-purpose analysis stayed within run-to-run
noise) - as expected, since the removed term only dominates once a seed's result set is large.

## Testing

`mvn test -DtestSetup=SootUp` on `boomerangPDS` and `idealPDS`: 352 and 113 tests, **identical
results to the base commit** — 0 failures, same skip counts.

Downstream, an asserted end-to-end Android analysis produced byte-identical findings before and
after, across every APK tested.